### PR TITLE
Upgrade to dcs-packaging-shared 1.0.1-SNAPSHOT

### DIFF
--- a/osf-packager/pom.xml
+++ b/osf-packager/pom.xml
@@ -192,18 +192,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.dataconservancy.pkgtool</groupId>
-        <artifactId>dcs-packaging-tool-impl</artifactId>
-        <version>1.0.3</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.dataconservancy.pkgtool</groupId>
-        <artifactId>dcs-packaging-tool-model-builder-properties</artifactId>
-        <version>1.0.3</version>
-      </dependency>
-
-      <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
         <version>2.32</version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <okhttp.version>2.5.0</okhttp.version>
         <spring.version>4.2.0.RELEASE</spring.version>
         <jsonapi-converter.version>0.5</jsonapi-converter.version>
-        <dcs-packaging-shared.version>1.0.0</dcs-packaging-shared.version>
+        <dcs-packaging-shared.version>1.0.1-SNAPSHOT</dcs-packaging-shared.version>
     </properties>
 
     <!-- Build  ===================================================== -->


### PR DESCRIPTION
 - Brings in latest changes to the PTG package generation code
- clean up errant dependencies in osf-packager.