### PR TITLE
Allow packager to work generally on nodes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ target/
 .svn/
 *.project
 *.classpath
+*.settings
+*.checkstyle
 osf-client.json
 osf-client-test.json
 osf-client-test.json

--- a/osf-packager/osf-packager-cli/src/main/java/org/dataconservancy/cos/packaging/cli/PackageGenerationApp.java
+++ b/osf-packager/osf-packager-cli/src/main/java/org/dataconservancy/cos/packaging/cli/PackageGenerationApp.java
@@ -21,6 +21,8 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+
+import org.dataconservancy.cos.osf.client.model.Node;
 import org.dataconservancy.cos.osf.client.model.Registration;
 import org.dataconservancy.cos.osf.client.model.User;
 import org.dataconservancy.cos.osf.client.retrofit.OsfService;
@@ -215,7 +217,7 @@ public class PackageGenerationApp {
     private void run() throws Exception {
         // Prepare the OSF registration and users information
         final OsfService osfService = CTX.getBean("osfService", OsfService.class);
-        final Registration registration = osfService.registration(registrationUrl).execute().body();
+        final Node registration = osfService.node(registrationUrl).execute().body();
 
         if (registration == null) {
             System.err.println("Failed to obtain registration " + registrationUrl + " from endpoint. " +

--- a/osf-packager/osf-packager-model/src/main/java/org/dataconservancy/cos/osf/packaging/OsfPackageGraph.java
+++ b/osf-packager/osf-packager-model/src/main/java/org/dataconservancy/cos/osf/packaging/OsfPackageGraph.java
@@ -22,6 +22,8 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Selector;
 import org.apache.jena.rdf.model.Statement;
+
+import org.dataconservancy.cos.osf.client.model.Node;
 import org.dataconservancy.cos.osf.client.model.Registration;
 import org.dataconservancy.cos.osf.client.model.User;
 import org.dataconservancy.cos.rdf.support.AnnotationsProcessor;
@@ -133,6 +135,15 @@ public class OsfPackageGraph extends ManagedGraph {
      */
     public Map<String, Individual> add(final Registration registration) {
         return processor.process(registration);
+    }
+
+    /** Adds an OSF node to the graph.
+     * 
+     * @param node OSF node
+     * @return a {@code Map} containing the URIs and OWL individuals added to the graph
+     */
+    public Map<String, Individual> add(final Node node) {
+        return processor.process(node);
     }
 
     /**

--- a/osf-packager/osf-packager-provider/src/main/java/org/dataconservancy/cos/packaging/OsfContentProvider.java
+++ b/osf-packager/osf-packager-provider/src/main/java/org/dataconservancy/cos/packaging/OsfContentProvider.java
@@ -237,6 +237,7 @@ public class OsfContentProvider extends AbstractContentProvider {
         final File outFile;
         try {
             outFile = new File(temporaryDirectory, filename);
+            outFile.getParentFile().mkdirs();
             IOUtils.copy(contentResolver.resolve(contentUrl), new FileOutputStream(outFile));
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);


### PR DESCRIPTION
Removes restriction/assumption that a registration is being packaged.
This allows the CLI to export projects, for example.